### PR TITLE
feat(resource): add CreationTimestamp to GKECluster

### DIFF
--- a/resources/gke-cluster.go
+++ b/resources/gke-cluster.go
@@ -53,12 +53,13 @@ func (l *GKEClusterLister) ListClusters(ctx context.Context, project, location s
 		}
 
 		resources = append(resources, &GKECluster{
-			svc:     l.svc,
-			Project: ptr.String(project),
-			Region:  ptr.String(region),
-			Name:    ptr.String(cluster.Name),
-			Zone:    ptr.String(zone),
-			Status:  ptr.String(cluster.Status.String()),
+			svc:               l.svc,
+			Project:           ptr.String(project),
+			Region:            ptr.String(region),
+			Name:              ptr.String(cluster.Name),
+			Zone:              ptr.String(zone),
+			Status:            ptr.String(cluster.Status.String()),
+			CreationTimestamp: ptr.String(cluster.CreateTime),
 		})
 	}
 
@@ -96,13 +97,14 @@ func (l *GKEClusterLister) List(ctx context.Context, o interface{}) ([]resource.
 }
 
 type GKECluster struct {
-	svc      *container.ClusterManagerClient
-	removeOp *containerpb.Operation
-	Project  *string
-	Region   *string
-	Name     *string
-	Zone     *string
-	Status   *string
+	svc               *container.ClusterManagerClient
+	removeOp          *containerpb.Operation
+	Project           *string
+	Region            *string
+	Name              *string
+	Zone              *string
+	Status            *string
+	CreationTimestamp *string
 }
 
 func (r *GKECluster) Remove(ctx context.Context) error {


### PR DESCRIPTION
Add the ability to filter `GKECluster` resources based on their creation timestamp the same way it is already possible for `ComputeInstance`.

The following configuration:
```yaml
regions:
  - all

blocklist:
  - ""

resource-types:
  includes:
    - ComputeInstance
    - GKECluster

accounts:
  "datadog-agent-sandbox":
    presets:
      - cleanup

presets:
  cleanup:
    filters:
      ComputeInstance:
        - property: CreationTimestamp
          type: dateOlderThan
          value: "48h"
      GKECluster:
        - property: CreationTimestamp
          type: dateOlderThan
          value: "48h"
```

now generates the following output:
```
us-central1 - GKECluster - gcp-gke-bc54253 - [CreationTimestamp: "2025-08-20T12:28:58+00:00", Name: "gcp-gke-bc54253", Project: "datadog-agent-sandbox", Region: "us-central1", Status: "RUNNING", Zone: ""] - filtered: filtered by config
```