### PR TITLE
feat: add DisableDeletionProtection support to ComputeInstance

### DIFF
--- a/docs/resources/compute-instance.md
+++ b/docs/resources/compute-instance.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
+- **`CreationTimestamp`**: No description provided
 - **`Labels`**: No description provided
+- **`Name`**: No description provided
 - **`Project`**: No description provided
 - **`Region`**: No description provided
-- **`Name`**: No description provided
 - **`Zone`**: No description provided
-- **`CreationTimestamp`**: No description provided
 ## Settings
 
 - `DisableDeletionProtection`

--- a/docs/resources/compute-instance.md
+++ b/docs/resources/compute-instance.md
@@ -7,9 +7,12 @@
 
 ## Properties
 
-- **`CreationTimestamp`**: No description provided
 - **`Labels`**: No description provided
-- **`Name`**: No description provided
 - **`Project`**: No description provided
 - **`Region`**: No description provided
+- **`Name`**: No description provided
 - **`Zone`**: No description provided
+- **`CreationTimestamp`**: No description provided
+## Settings
+
+- `DisableDeletionProtection`

--- a/resources/compute-instance.go
+++ b/resources/compute-instance.go
@@ -14,6 +14,7 @@ import (
 	compute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
 
+	liberror "github.com/ekristen/libnuke/pkg/errors"
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/settings"
@@ -95,12 +96,14 @@ func (l *ComputeInstanceLister) List(ctx context.Context, o interface{}) ([]reso
 }
 
 type ComputeInstance struct {
-	svc               *compute.InstancesClient
-	settings          *settings.Setting
-	Project           *string
-	Region            *string
-	Name              *string
-	Zone              *string
+	svc          *compute.InstancesClient
+	settings     *settings.Setting
+	protectionOp *compute.Operation
+	removeOp     *compute.Operation
+	Project      *string
+	Region       *string
+	Name         *string
+	Zone         *string
 	CreationTimestamp *string
 	Labels            map[string]string `property:"tagPrefix=label"`
 }
@@ -110,16 +113,69 @@ func (r *ComputeInstance) Settings(setting *settings.Setting) {
 }
 
 func (r *ComputeInstance) Remove(ctx context.Context) error {
-	if err := r.disableDeletionProtection(ctx); err != nil {
-		return err
+	if r.settings != nil && r.settings.GetBool("DisableDeletionProtection") {
+		var err error
+		r.protectionOp, err = r.svc.SetDeletionProtection(ctx, &computepb.SetDeletionProtectionInstanceRequest{
+			Project:            *r.Project,
+			Zone:               *r.Zone,
+			Resource:           *r.Name,
+			DeletionProtection: proto.Bool(false),
+		})
+		if err != nil {
+			return fmt.Errorf("unable to disable deletion protection: %w", err)
+		}
+		return nil
 	}
 
-	_, err := r.svc.Delete(ctx, &computepb.DeleteInstanceRequest{
+	return r.delete(ctx)
+}
+
+func (r *ComputeInstance) delete(ctx context.Context) (err error) {
+	r.removeOp, err = r.svc.Delete(ctx, &computepb.DeleteInstanceRequest{
 		Project:  *r.Project,
 		Zone:     *r.Zone,
 		Instance: *r.Name,
 	})
 	return err
+}
+
+func (r *ComputeInstance) HandleWait(ctx context.Context) error {
+	if r.protectionOp != nil {
+		if err := r.protectionOp.Poll(ctx); err != nil {
+			logrus.WithError(err).Trace("protection op polling encountered error")
+			return err
+		}
+		if !r.protectionOp.Done() {
+			return liberror.ErrWaitResource("waiting for deletion protection to be disabled")
+		}
+		if r.protectionOp.Proto().GetError() != nil {
+			return fmt.Errorf("disable deletion protection error on '%s': %s",
+				r.protectionOp.Proto().GetTargetLink(), r.protectionOp.Proto().GetHttpErrorMessage())
+		}
+		r.protectionOp = nil
+
+		if err := r.delete(context.TODO()); err != nil {
+			return err
+		}
+	}
+
+	if r.removeOp == nil {
+		return nil
+	}
+
+	if err := r.removeOp.Poll(ctx); err != nil {
+		logrus.WithError(err).Trace("remove op polling encountered error")
+		return err
+	}
+	if !r.removeOp.Done() {
+		return liberror.ErrWaitResource("waiting for instance to be deleted")
+	}
+	if r.removeOp.Proto().GetError() != nil {
+		return fmt.Errorf("delete error on '%s': %s",
+			r.removeOp.Proto().GetTargetLink(), r.removeOp.Proto().GetHttpErrorMessage())
+	}
+
+	return nil
 }
 
 func (r *ComputeInstance) Properties() types.Properties {
@@ -130,24 +186,3 @@ func (r *ComputeInstance) String() string {
 	return *r.Name
 }
 
-func (r *ComputeInstance) disableDeletionProtection(ctx context.Context) error {
-	if r.settings == nil || !r.settings.GetBool("DisableDeletionProtection") {
-		return nil
-	}
-
-	op, err := r.svc.SetDeletionProtection(ctx, &computepb.SetDeletionProtectionInstanceRequest{
-		Project:            *r.Project,
-		Zone:               *r.Zone,
-		Resource:           *r.Name,
-		DeletionProtection: proto.Bool(false),
-	})
-	if err != nil {
-		return fmt.Errorf("unable to disable deletion protection: %w", err)
-	}
-
-	if err := op.Wait(ctx); err != nil {
-		return fmt.Errorf("unable to wait for deletion protection update operation: %w", err)
-	}
-
-	return nil
-}

--- a/resources/compute-instance.go
+++ b/resources/compute-instance.go
@@ -3,9 +3,11 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/gotidy/ptr"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/proto"
 
 	"google.golang.org/api/iterator"
 
@@ -14,6 +16,7 @@ import (
 
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/settings"
 	"github.com/ekristen/libnuke/pkg/types"
 
 	"github.com/ekristen/gcp-nuke/pkg/nuke"
@@ -27,6 +30,9 @@ func init() {
 		Scope:    nuke.Project,
 		Resource: &ComputeInstance{},
 		Lister:   &ComputeInstanceLister{},
+		Settings: []string{
+			"DisableDeletionProtection",
+		},
 	})
 }
 
@@ -90,6 +96,7 @@ func (l *ComputeInstanceLister) List(ctx context.Context, o interface{}) ([]reso
 
 type ComputeInstance struct {
 	svc               *compute.InstancesClient
+	settings          *settings.Setting
 	Project           *string
 	Region            *string
 	Name              *string
@@ -98,7 +105,15 @@ type ComputeInstance struct {
 	Labels            map[string]string `property:"tagPrefix=label"`
 }
 
+func (r *ComputeInstance) Settings(setting *settings.Setting) {
+	r.settings = setting
+}
+
 func (r *ComputeInstance) Remove(ctx context.Context) error {
+	if err := r.disableDeletionProtection(ctx); err != nil {
+		return err
+	}
+
 	_, err := r.svc.Delete(ctx, &computepb.DeleteInstanceRequest{
 		Project:  *r.Project,
 		Zone:     *r.Zone,
@@ -113,4 +128,26 @@ func (r *ComputeInstance) Properties() types.Properties {
 
 func (r *ComputeInstance) String() string {
 	return *r.Name
+}
+
+func (r *ComputeInstance) disableDeletionProtection(ctx context.Context) error {
+	if r.settings == nil || !r.settings.GetBool("DisableDeletionProtection") {
+		return nil
+	}
+
+	op, err := r.svc.SetDeletionProtection(ctx, &computepb.SetDeletionProtectionInstanceRequest{
+		Project:            *r.Project,
+		Zone:               *r.Zone,
+		Resource:           *r.Name,
+		DeletionProtection: proto.Bool(false),
+	})
+	if err != nil {
+		return fmt.Errorf("unable to disable deletion protection: %w", err)
+	}
+
+	if err := op.Wait(ctx); err != nil {
+		return fmt.Errorf("unable to wait for deletion protection update operation: %w", err)
+	}
+
+	return nil
 }

--- a/resources/compute-instance.go
+++ b/resources/compute-instance.go
@@ -154,7 +154,7 @@ func (r *ComputeInstance) HandleWait(ctx context.Context) error {
 		}
 		r.protectionOp = nil
 
-		if err := r.delete(context.TODO()); err != nil {
+		if err := r.delete(ctx); err != nil {
 			return err
 		}
 	}

--- a/resources/compute-instance.go
+++ b/resources/compute-instance.go
@@ -96,14 +96,14 @@ func (l *ComputeInstanceLister) List(ctx context.Context, o interface{}) ([]reso
 }
 
 type ComputeInstance struct {
-	svc          *compute.InstancesClient
-	settings     *settings.Setting
-	protectionOp *compute.Operation
-	removeOp     *compute.Operation
-	Project      *string
-	Region       *string
-	Name         *string
-	Zone         *string
+	svc               *compute.InstancesClient
+	settings          *settings.Setting
+	protectionOp      *compute.Operation
+	removeOp          *compute.Operation
+	Project           *string
+	Region            *string
+	Name              *string
+	Zone              *string
 	CreationTimestamp *string
 	Labels            map[string]string `property:"tagPrefix=label"`
 }
@@ -114,6 +114,8 @@ func (r *ComputeInstance) Settings(setting *settings.Setting) {
 
 func (r *ComputeInstance) Remove(ctx context.Context) error {
 	if r.settings != nil && r.settings.GetBool("DisableDeletionProtection") {
+		logrus.Trace("disabling deletion protection")
+
 		var err error
 		r.protectionOp, err = r.svc.SetDeletionProtection(ctx, &computepb.SetDeletionProtectionInstanceRequest{
 			Project:            *r.Project,
@@ -185,4 +187,3 @@ func (r *ComputeInstance) Properties() types.Properties {
 func (r *ComputeInstance) String() string {
 	return *r.Name
 }
-

--- a/resources/compute-instance_test.go
+++ b/resources/compute-instance_test.go
@@ -28,22 +28,26 @@ func TestComputeInstanceRegistrationIncludesDisableDeletionProtection(t *testing
 	}
 }
 
-func TestComputeInstanceRemoveSkipsProtectionWhenSettingDisabled(t *testing.T) {
+func TestComputeInstanceInitialStateHasNoOps(t *testing.T) {
 	r := &ComputeInstance{}
 	r.Settings(&settings.Setting{"DisableDeletionProtection": false})
 
-	// svc is nil so delete would panic if called; no panic means protection was skipped correctly
-	// but delete() will still be called, so we just verify no panic on the protection path
 	if r.protectionOp != nil {
-		t.Fatal("expected protectionOp to be nil")
+		t.Fatal("expected protectionOp to be nil at initial state")
+	}
+	if r.removeOp != nil {
+		t.Fatal("expected removeOp to be nil at initial state")
 	}
 }
 
-func TestComputeInstanceRemoveSkipsProtectionWhenSettingsNil(t *testing.T) {
+func TestComputeInstanceInitialStateHasNoOpsWhenSettingsNil(t *testing.T) {
 	r := &ComputeInstance{}
 
 	if r.protectionOp != nil {
-		t.Fatal("expected protectionOp to be nil")
+		t.Fatal("expected protectionOp to be nil at initial state")
+	}
+	if r.removeOp != nil {
+		t.Fatal("expected removeOp to be nil at initial state")
 	}
 }
 

--- a/resources/compute-instance_test.go
+++ b/resources/compute-instance_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/settings"
 )
 
@@ -27,21 +28,34 @@ func TestComputeInstanceRegistrationIncludesDisableDeletionProtection(t *testing
 	}
 }
 
-func TestComputeInstanceDisableDeletionProtectionReturnsNilWhenSettingDisabled(t *testing.T) {
+func TestComputeInstanceRemoveSkipsProtectionWhenSettingDisabled(t *testing.T) {
 	r := &ComputeInstance{}
 	r.Settings(&settings.Setting{"DisableDeletionProtection": false})
 
-	err := r.disableDeletionProtection(context.Background())
+	// svc is nil so delete would panic if called; no panic means protection was skipped correctly
+	// but delete() will still be called, so we just verify no panic on the protection path
+	if r.protectionOp != nil {
+		t.Fatal("expected protectionOp to be nil")
+	}
+}
+
+func TestComputeInstanceRemoveSkipsProtectionWhenSettingsNil(t *testing.T) {
+	r := &ComputeInstance{}
+
+	if r.protectionOp != nil {
+		t.Fatal("expected protectionOp to be nil")
+	}
+}
+
+func TestComputeInstanceHandleWaitReturnsNilWhenNoOps(t *testing.T) {
+	r := &ComputeInstance{}
+
+	err := r.HandleWait(context.Background())
 	if err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
 }
 
-func TestComputeInstanceDisableDeletionProtectionReturnsNilWhenSettingsNil(t *testing.T) {
-	r := &ComputeInstance{}
-
-	err := r.disableDeletionProtection(context.Background())
-	if err != nil {
-		t.Fatalf("expected nil error, got: %v", err)
-	}
+func TestComputeInstanceImplementsHandleWaitHook(t *testing.T) {
+	var _ resource.HandleWaitHook = &ComputeInstance{}
 }

--- a/resources/compute-instance_test.go
+++ b/resources/compute-instance_test.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/settings"
+)
+
+func TestComputeInstanceRegistrationIncludesDisableDeletionProtection(t *testing.T) {
+	reg := registry.GetRegistration(ComputeInstanceResource)
+	if reg == nil {
+		t.Fatal("registration for ComputeInstance was not found")
+	}
+
+	hasSetting := false
+	for _, settingName := range reg.Settings {
+		if settingName == "DisableDeletionProtection" {
+			hasSetting = true
+			break
+		}
+	}
+
+	if !hasSetting {
+		t.Fatal("ComputeInstance registration is missing DisableDeletionProtection setting")
+	}
+}
+
+func TestComputeInstanceDisableDeletionProtectionReturnsNilWhenSettingDisabled(t *testing.T) {
+	r := &ComputeInstance{}
+	r.Settings(&settings.Setting{"DisableDeletionProtection": false})
+
+	err := r.disableDeletionProtection(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+}
+
+func TestComputeInstanceDisableDeletionProtectionReturnsNilWhenSettingsNil(t *testing.T) {
+	r := &ComputeInstance{}
+
+	err := r.disableDeletionProtection(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+}


### PR DESCRIPTION
### Improvements

- Added `DisableDeletionProtection` to `ComputeInstance` resource settings
- Implemented `SettingsGetter` support for `ComputeInstance`
- Replaced blocking `op.Wait()` with `HandleWait` pattern for non-blocking async polling
  - `Remove()`: Issues `SetDeletionProtection(false)` and saves the operation, returning immediately
  - `HandleWait()`: Polls the protection operation → calls `Delete` on completion → polls the delete operation
- Added tests for settings registration, initial state verification, `HandleWaitHook` interface compliance, and no-op behavior
- Updated `docs/resources/compute-instance.md` to include `## Settings` section

### Testing

<details>
<summary>Unit tests</summary>

```sh
go test ./resources -run ComputeInstance -v
# => PASS
```
</details>

<details>
<summary>Manual verification (real project)</summary>

```sh
# 1) Create VM with deletion protection
gcloud compute instances create test-deletion-protection \
  --project xxx --zone us-east1-b --machine-type e2-micro \
  --image-family debian-12 --image-project debian-cloud \
  --boot-disk-size 10GB --deletion-protection

# 2) Confirm deletionProtection=true
gcloud compute instances describe test-deletion-protection \
  --project xxx --zone us-east1-b --format json(name,deletionProtection,status)
# => deletionProtection: true

# 3) Run gcp-nuke with ComputeInstance + DisableDeletionProtection
go run . run --config .tmp-verify-compute-instance.yaml \
  --project-id xxx --include ComputeInstance --no-dry-run --no-prompt
# => Nuke complete: 0 failed, 0 skipped, 1 finished

# 4) Confirm instance no longer exists
gcloud compute instances describe test-deletion-protection \
  --project xxx --zone us-east1-b
# => resource was not found
```
</details>

### Reference

- Google Cloud `SetDeletionProtection` API: https://docs.cloud.google.com/compute/docs/samples/compute-delete-protection-set
- `HandleWait` pattern is consistent with existing resources (e.g. `ComputeURLMap`, `ComputeBackendService`)